### PR TITLE
Fix buying Nameless hints

### DIFF
--- a/src/core/celestials/enslaved.js
+++ b/src/core/celestials/enslaved.js
@@ -219,7 +219,7 @@ export const Enslaved = {
     if (player.celestials.enslaved.stored < this.nextHintCost) return false;
     player.celestials.enslaved.stored -= this.nextHintCost;
     if (Enslaved.hintCostIncreases === 0) {
-      player.celestials.enslaved.zeroHintTime = Date.now() + TimeSpan.fromDays(1).totalMilliseconds.toNumber;
+      player.celestials.enslaved.zeroHintTime = Date.now() + TimeSpan.fromDays(1).totalMilliseconds.toNumber();
     } else {
       player.celestials.enslaved.zeroHintTime += TimeSpan.fromDays(1).totalMilliseconds.toNumber();
     }


### PR DESCRIPTION
`TimeSpan.fromDays(1).totalMilliseconds.toNumber` is a function, not a numeric property.