### PR TITLE
Fix some errors while importing BE saves

### DIFF
--- a/src/core/player-progress.js
+++ b/src/core/player-progress.js
@@ -17,7 +17,7 @@ export class PlayerProgress {
   }
 
   get isRealityUnlocked() {
-    return this._player.realities.gt(0);
+    return new Decimal(this._player.realities).gt(0);
   }
 
   get hasFullCompletion() {

--- a/src/core/storage/storage.js
+++ b/src/core/storage/storage.js
@@ -336,7 +336,7 @@ export const GameStorage = {
   // since these may cause the backup timer to be significantly behind
   resetBackupTimer() {
     const latestBackupTime = Object.values(this.lastBackupTimes).map(t => t && t.backupTimer).max();
-    player.backupTimer = Math.max(this.oldBackupTimer, player.backupTimer, latestBackupTime);
+    player.backupTimer = Math.max(this.oldBackupTimer, player.backupTimer, latestBackupTime.toNumber());
   },
 
   // Saves the current game state to the first reserve slot it finds


### PR DESCRIPTION
Importing BE saves failed due to an implicit conversion of Decimal to Number on Realities in the save preview, as well as another implicit Decimal to Number conversion when resetting the backup timer.