### PR TITLE
Apply remaining changes from upstream post-open-source

### DIFF
--- a/public/stylesheets/theme-Metro.css
+++ b/public/stylesheets/theme-Metro.css
@@ -18,3 +18,7 @@
 .t-metro .c-tt-buy-button--locked:hover {
   background: #ef5350;
 }
+
+.o-tachyon-particle {
+  fill: black !important;
+}

--- a/src/components/modals/prestige/RealityModal.vue
+++ b/src/components/modals/prestige/RealityModal.vue
@@ -91,7 +91,7 @@ export default {
       this.hasFilter = EffarigUnlock.glyphFilter.isUnlocked;
       this.level = gainedGlyphLevel().actualLevel;
       this.simRealities = 1 + simulatedRealityCount(false);
-      this.hasSpace = GameCache.glyphInventorySpace.value > this.simRealities;
+      this.hasSpace = GameCache.glyphInventorySpace.value >= this.simRealities;
       const simRMGained = MachineHandler.gainedRealityMachines.times(this.simRealities);
       this.realityMachines.copyFrom(simRMGained.clampMax(MachineHandler.distanceToRMCap));
       this.shardsGained = Effarig.shardsGained * (simulatedRealityCount(false) + 1);

--- a/src/components/tabs/autobuyers/AutobuyerInput.vue
+++ b/src/components/tabs/autobuyers/AutobuyerInput.vue
@@ -69,7 +69,7 @@ export default {
     handleFocus() {
       this.isFocused = true;
     },
-    handleBlur() {
+    handleChange(event) {
       if (this.displayValue === "69") {
         SecretAchievement(28).unlock();
       }
@@ -81,6 +81,7 @@ export default {
       this.updateDisplayValue();
       this.isValid = true;
       this.isFocused = false;
+      event.target.blur();
     }
   }
 };
@@ -142,7 +143,7 @@ export const AutobuyerInputFunctions = {
     :class="validityClass"
     :type="inputType"
     class="o-autobuyer-input"
-    @blur="handleBlur"
+    @change="handleChange"
     @focus="handleFocus"
     @input="handleInput"
   >

--- a/src/core/automator/automator-commands.js
+++ b/src/core/automator/automator-commands.js
@@ -401,7 +401,7 @@ export const AutomatorCommands = [
           S.commandState = { timeMs: 0 };
           AutomatorData.logCommandEvent(`Pause started (waiting ${timeString})`, ctx.startLine);
         } else {
-          S.commandState.timeMs += Math.max(Time.unscaledDeltaTime.milliseconds, AutomatorBackend.currentInterval);
+          S.commandState.timeMs += Math.max(Time.trueDeltaTime.totalMilliseconds, AutomatorBackend.currentInterval);
         }
         const finishPause = S.commandState.timeMs >= duration;
         if (finishPause) {

--- a/src/core/secret-formula/news.js
+++ b/src/core/secret-formula/news.js
@@ -2041,7 +2041,7 @@ export const news = [
     id: "a325",
     text:
       `After the accident at the antimatter reactor in Pripyat last month, concerns are rising about the safety of
-      antimattter reactors, and many are starting to believe we should return to safer means of energy generation,
+      antimatter reactors, and many are starting to believe we should return to safer means of energy generation,
       such as nuclear.`
   },
   {


### PR DESCRIPTION
#5 missed a couple of bug fixes and a minor cosmetic change that was implemented upstream after open-sourcing AD; this PR ports these changes over.

As of the time of writing, there are no significant commits left to port over from upstream; all remaining commits either cancel each other out or have to do with things that will not be implemented in BE, such as the shop.