### PR TITLE
Decimalize the repeatable IP multiplier upgrade

### DIFF
--- a/src/core/eternity.js
+++ b/src/core/eternity.js
@@ -195,7 +195,7 @@ export function initializeResourcesAfterEternity() {
   player.galaxies = (EternityMilestone.keepInfinityUpgrades.isReached) ? DC.D1 : DC.D0;
   player.partInfinityPoint = 0;
   player.partInfinitied = 0;
-  player.IPMultPurchases = 0;
+  player.IPMultPurchases = DC.D0;
   Currency.infinityPower.reset();
   Currency.timeShards.reset();
   player.records.thisEternity.time = DC.D0;

--- a/src/core/infinity-upgrades.js
+++ b/src/core/infinity-upgrades.js
@@ -134,11 +134,11 @@ export function disChargeAll() {
 // GameDatabase.infinity.upgrades.ipMult
 class InfinityIPMultUpgrade extends GameMechanicState {
   get cost() {
-    if (this.purchaseCount >= this.purchasesAtIncrease) {
+    if (this.purchaseCount.gte(this.purchasesAtIncrease)) {
       return this.config.costIncreaseThreshold
-        .times(Decimal.pow(this.costIncrease, this.purchaseCount - this.purchasesAtIncrease));
+        .times(Decimal.pow(this.costIncrease, this.purchaseCount.sub(this.purchasesAtIncrease)));
     }
-    return Decimal.pow(this.costIncrease, this.purchaseCount + 1);
+    return Decimal.pow(this.costIncrease, this.purchaseCount.add(1));
   }
 
   get purchaseCount() {
@@ -146,11 +146,11 @@ class InfinityIPMultUpgrade extends GameMechanicState {
   }
 
   get purchasesAtIncrease() {
-    return this.config.costIncreaseThreshold.log10().toNumber - 1;
+    return this.config.costIncreaseThreshold.log10().sub(1);
   }
 
   get hasIncreasedCost() {
-    return this.purchaseCount >= this.purchasesAtIncrease;
+    return this.purchaseCount.gte(this.purchasesAtIncrease);
   }
 
   get costIncrease() {
@@ -158,7 +158,7 @@ class InfinityIPMultUpgrade extends GameMechanicState {
   }
 
   get isCapped() {
-    return this.cost.gte(this.config.costCap) || player.IPMultPurchases > 3300000;
+    return this.cost.gte(this.config.costCap) || player.IPMultPurchases.gt(3300000);
   }
 
   get isBought() {
@@ -181,7 +181,7 @@ class InfinityIPMultUpgrade extends GameMechanicState {
       Autobuyer.bigCrunch.bumpAmount(DC.D2.pow(amount));
     }
     Currency.infinityPoints.subtract(Decimal.sumGeometricSeries(amount, this.cost, this.costIncrease, 0));
-    player.IPMultPurchases += amount;
+    player.IPMultPurchases = player.IPMultPurchases.add(amount);
     GameUI.update();
   }
 
@@ -190,8 +190,8 @@ class InfinityIPMultUpgrade extends GameMechanicState {
     if (!this.hasIncreasedCost) {
       // Only allow IP below the softcap to be used
       const availableIP = Currency.infinityPoints.value.clampMax(this.config.costIncreaseThreshold);
-      const purchases = Decimal.affordGeometricSeries(availableIP, this.cost, this.costIncrease, 0).toNumber();
-      if (purchases <= 0) return;
+      const purchases = Decimal.affordGeometricSeries(availableIP, this.cost, this.costIncrease, 0);
+      if (purchases.lte(0)) return;
       this.purchase(purchases);
     }
     // Do not replace it with `if else` - it's specifically designed to process two sides of threshold separately
@@ -199,8 +199,8 @@ class InfinityIPMultUpgrade extends GameMechanicState {
     // it will go in this part)
     if (this.hasIncreasedCost) {
       const availableIP = Currency.infinityPoints.value.clampMax(this.config.costCap);
-      const purchases = Decimal.affordGeometricSeries(availableIP, this.cost, this.costIncrease, 0).toNumber();
-      if (purchases <= 0) return;
+      const purchases = Decimal.affordGeometricSeries(availableIP, this.cost, this.costIncrease, 0);
+      if (purchases.lte(0)) return;
       this.purchase(purchases);
     }
   }

--- a/src/core/player.js
+++ b/src/core/player.js
@@ -370,7 +370,7 @@ window.player = {
     initialSeed: 0,
     previousRuns: {}
   },
-  IPMultPurchases: 0,
+  IPMultPurchases: DC.D0,
   version: 83,
   infinityPower: DC.D1,
   postC4Tier: 0,

--- a/src/core/secret-formula/infinity/infinity-upgrades.js
+++ b/src/core/secret-formula/infinity/infinity-upgrades.js
@@ -226,7 +226,7 @@ export const infinityUpgrades = {
     description: () => `Multiply Infinity Points from all sources by ${formatX(2)}`,
     // Normally the multiplier caps at e993k or so with 3300000 purchases, but if the cost is capped then we just give
     // an extra e7k to make the multiplier look nice
-    effect: () => (player.IPMultPurchases >= 3300000 ? DC.E1E6 : DC.D2.pow(player.IPMultPurchases)),
+    effect: () => (player.IPMultPurchases.gte(3300000) ? DC.E1E6 : DC.D2.pow(player.IPMultPurchases)),
     cap: () => Effarig.eternityCap ?? DC.E1E6,
     formatEffect: value => formatX(value, 2, 2),
   }


### PR DESCRIPTION
This is useful if mods want to uncap the repeatable IP multiplier upgrade.

If the endgame is extended to F9e15 antimatter, nine times out of ten, the repeatable IP multiplier upgrade will be able to be purchased more than e308 times, even if its cost scales faster with more purchases.