### PR TITLE
Fix an error in the progress checker

### DIFF
--- a/src/core/secret-formula/progress-checker.js
+++ b/src/core/secret-formula/progress-checker.js
@@ -79,7 +79,7 @@ export const progressStages = [
     id: PROGRESS_STAGE.LATE_ETERNITY,
     name: "Late Eternity",
     hasReached: save => new Decimal(save.dilation.dilatedTime).gt(1e15),
-    suggestedResource: () => (new Decimal(player.eternityPoints).log10() > 4000
+    suggestedResource: () => (new Decimal(player.eternityPoints).log10().gt(4000)
       ? "Eternity Points and/or Dilated Time. Alternatively, you can unlock and perform your first Reality"
       : "Eternity Points and/or Dilated Time"
     ),


### PR DESCRIPTION
When loading a save that has purchased the Time Theorem generation Dilation Upgrade but not yet performed a Reality, the catchup modal throws an error due to an implicit conversion from Decimal to Number when checking if the save has enough Eternity Points to unlock Reality.