### PR TITLE
Fix implicit Decimal to Number conversion in function `blendCel`

### DIFF
--- a/src/core/celestials/quotes.js
+++ b/src/core/celestials/quotes.js
@@ -34,7 +34,7 @@ export const Quote = {
 // Gives an array specifying proportions of celestials to blend together on the modal, as a function of time, to
 // provide a smoother transition between different celestials to reduce potential photosensitivity issues
 function blendCel(cels) {
-  const totalTime = cels.map(cel => cel[1]).sum();
+  const totalTime = cels.map(cel => cel[1]).nSum();
   const tick = (Date.now() / 1000) % totalTime;
 
   // Blend the first blendTime seconds with the previous celestial and the last blendTime seconds with the next;


### PR DESCRIPTION
`Array.sum` in line 37 of the `blendCel` function returns a Decimal, causing an "Implicit conversion from Decimal to Number" error on the next line. Use `Array.nSum` instead, which returns a Number.