### PR TITLE
Fix GameEnd state determination

### DIFF
--- a/src/core/celestials/pelle/game-end.js
+++ b/src/core/celestials/pelle/game-end.js
@@ -18,12 +18,9 @@ export const END_STATE_MARKERS = {
 
 export const GameEnd = {
   get endState() {
-    if (this.removeAdditionalEnd) return this.additionalEnd;
-    let x = 0;
-    if (player.celestials.pelle.records.totalAntimatter.layer >= 2 && player.bypassEnd !== true) {
-      x = player.celestials.pelle.records.totalAntimatter.max(1).log10().sub(9e15).min(5000).toNumber();
-    }
-    return Math.max(x, 0);
+    if (this.removeAdditionalEnd || player.bypassEnd) return this.additionalEnd;
+    return Math.max(player.celestials.pelle.records.totalAntimatter.add(1).log10().add(1).log10().sub(8.7)
+      .div(Math.log10(9e15) - 8.7).min(1).toNumber() + this.additionalEnd, 0);
   },
 
   _additionalEnd: 0,


### PR DESCRIPTION
This brings the calculation of `GameEnd.endState` back in line with the vanilla game, bringing back tab zalgoification in the process.

The `endState` calculation was previously changed to check if the layer count of the total antimatter was at least 2, which meant `endState` would jump from 0 to at least 1 as soon as total Antimatter hit e9e15, bypassing not only tab zalgoification but also (depending on Antimatter count) other phases of the end sequence.

For reference, the corresponding code in vanilla AD can be found here: https://github.com/IvarK/AntimatterDimensionsSourceCode/blob/aeaa7a358f605073172ec9eaa28ff6544edca5a5/src/core/celestials/pelle/game-end.js#L18-L22
```js
get endState() {
  if (this.removeAdditionalEnd) return this.additionalEnd;
  return Math.max((Math.log10(player.celestials.pelle.records.totalAntimatter.plus(1).log10() + 1) - 8.7) /
    (Math.log10(9e15) - 8.7) + this.additionalEnd, 0);
},
```