### PR TITLE
Fix #23: Tesseract effect was amplified over time, breaking game balance

### DIFF
--- a/src/components/tabs/infinity-dimensions/ModernInfinityDimensionRow.vue
+++ b/src/components/tabs/infinity-dimensions/ModernInfinityDimensionRow.vue
@@ -33,7 +33,7 @@ export default {
       capIP: new Decimal(0),
       isAutobuyerOn: false,
       isEC8Running: false,
-      hardcap: InfinityDimensions.HARDCAP_PURCHASES,
+      hardcap: new Decimal(InfinityDimensions.HARDCAP_PURCHASES),
       eternityReached: false,
       enslavedRunning: false,
     };


### PR DESCRIPTION
Due to the way the Infinity Dimensions tab initialized its variables, staying on the tab and maxing out the number of purchases for an Infinity Dimension caused the base purchase cap to increase by the bonus from Tesseracts.

The net cause was a reactivity error that was not directly caught in my testing setup.

I've fixed this by initializing the relevant variable in a way that doesn't link or induce reactivity.

P.S. I now have one more idea for an upgrade or mechanic in a post-Reality layer:
> Tesseracts increase the Infinity Dimension purchase cap over time. Currently: +(bonus from Tesseracts × ___)/s