### PR TITLE
Fix incorrect migration of emoji galaxy counter

### DIFF
--- a/src/core/storage/be-migrations.js
+++ b/src/core/storage/be-migrations.js
@@ -252,6 +252,7 @@ export function beMigration(player) {
   player.replicanti.timer = D(player.replicanti.timer);
   player.requirementChecks.reality.slowestBH = D(player.requirementChecks.reality.slowestBH);
   player.requirementChecks.reality.maxID1 = D(player.requirementChecks.reality.maxID1);
+  player.requirementChecks.permanent.emojiGalaxies = D(player.requirementChecks.permanent.emojiGalaxies);
   player.totalTickGained = D(player.totalTickGained);
   player.totalTickBought = D(player.totalTickBought);
 }


### PR DESCRIPTION
Importing non-BE saves crashed during migration of the emoji galaxy counter, which counts the number of galaxies purchased while using emoji notations, because the counter was left either uninitialized or a Number, instead of a Decimal as expected throughout the rest of the code base.
This counter is used in a Secret Achievement and several news messages.