### PR TITLE
Fix Achievement power error while Doomed

### DIFF
--- a/src/core/achievements/normal-achievement.js
+++ b/src/core/achievements/normal-achievement.js
@@ -1,5 +1,5 @@
+import { DC } from "../constants";
 import { GameMechanicState } from "../game-mechanics";
-
 import { SteamRuntime } from "@/steam";
 
 class AchievementState extends GameMechanicState {


### PR DESCRIPTION
While Doomed, the Achievement multiplier is set to 1, but instead of `new Decimal(1)`, it was set to the constant `DC.D1` but `DC` was not imported.

By importing `DC`, I was able to fix the issue while simultaneously allowing modders to use all of its values in the achievement power calculation instead of constructing new Decimals on the spot.