### PR TITLE
Fix the Automation tab notification being always active

### DIFF
--- a/src/core/cache.js
+++ b/src/core/cache.js
@@ -96,7 +96,7 @@ export const GameCache = {
   cheapestAntimatterAutobuyer: new Lazy(() => Autobuyer.antimatterDimension.zeroIndexed.concat(Autobuyer.tickspeed)
     .filter(ab => !(ab.isBought || ab.isUnlocked))
     .map(ab => ab.antimatterCost.toNumber())
-    .min()
+    .nMin()
   ),
 
   // The effect is defined in antimatter_dimensions.js because that's where the non-cached


### PR DESCRIPTION
`GameCache.cheapestAntimatterAutobuyer.value` was converted to a Decimal, and casting the Decimal object to a boolean now returns true regardless of the value of said Decimal. When all autobuyers which can be bought at specific Antimatter thresholds are reached, `GameCache.cheapestAntimatterAutobuyer.value` jumps to 0, and as the Antimatter amount is strictly positive by that point, the second condition passes and the tab notification on the Automation tab triggers every frame.

I've fixed this by using `.nMin()` instead of `.min()` in the calculation, as `.min()` casts the result to a Decimal.