### PR TITLE
Fix double-notification on reaching exactly 1 singularity milestone in a single condense

### DIFF
--- a/src/core/celestials/laitela/singularity.js
+++ b/src/core/celestials/laitela/singularity.js
@@ -301,7 +301,7 @@ EventHub.logic.on(GAME_EVENT.SINGULARITY_RESET_AFTER, () => {
   const newMilestones = SingularityMilestones.unnotifiedMilestones.length;
   if (newMilestones === 0) return;
   if (newMilestones === 1) GameUI.notify.blackHole(`You reached a Singularity milestone!`);
-  if (newMilestones > 100) GameUI.notify.blackHole(`You reached over 100 Singularity milestones!`);
+  else if (newMilestones > 100) GameUI.notify.blackHole(`You reached over 100 Singularity milestones!`);
   else GameUI.notify.blackHole(`You reached ${formatInt(newMilestones)} Singularity milestones!`);
   SingularityMilestones.lastNotified = Currency.singularities.value;
 });


### PR DESCRIPTION
Reaching exactly one Singularity Milestone when condensing Dark Energy triggered both "You reached a Singularity Milestone" and "You reached 1 Singularity Milestones" notifications, the latter of which is extraneous.

An `if` should have been replaced by `else if` when checking that over 100 milestones were reached; doing that removed the extraneous notification.

Screenshot with double notification:
![image](https://github.com/user-attachments/assets/373ac1fb-d508-4561-a5ef-26fb825dec2b)